### PR TITLE
Secrets Please

### DIFF
--- a/charts/mini-runtime/templates/deployment.yaml
+++ b/charts/mini-runtime/templates/deployment.yaml
@@ -65,7 +65,10 @@ spec:
         - name: DATABASE_ABSTRACTOR_SERVICE_URL
           value: {{ quote .Values.mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorUrl}}
         - name: DATABASE_ABSTRACTOR_SERVICE_TOKEN
-          value: {{ quote .Values.mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorToken}}
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: {{ (tpl .Values.mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorToken.existingSecret .) | default (printf "%s-mini-runtime" (include "akto.fullname" .) ) }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.mini_runtime.aktoApiSecurityRuntime.image.repository }}:{{ .Values.mini_runtime.aktoApiSecurityRuntime.image.tag

--- a/charts/mini-runtime/templates/secret.yaml
+++ b/charts/mini-runtime/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorToken.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "akto.fullname" . }}-mini-runtime
+  labels:
+  {{- include "akto.labels" . | nindent 4 }}
+type: Opaque
+data:
+  token: {{ .Values.mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorToken.token | toString | b64enc | quote }}
+{{- end }}

--- a/charts/mini-runtime/values.yaml
+++ b/charts/mini-runtime/values.yaml
@@ -19,9 +19,9 @@ mini_runtime:
       useHostName: true
       databaseAbstractorUrl: https://aquaman.akto.io
       databaseAbstractorToken: 
-        # Optional -- Name of an existing secret containing the Database Abstractor Token
+        # Name of an existing secret containing the Database Abstractor Token
         existingSecret: ""
-        # Optional -- Token to use if existingSecret is not provided
+        # Token to use if existingSecret is not provided
         token: ""
     image:
       repository: public.ecr.aws/aktosecurity/akto-api-security-mini-runtime

--- a/charts/mini-runtime/values.yaml
+++ b/charts/mini-runtime/values.yaml
@@ -18,7 +18,11 @@ mini_runtime:
       puppeteerReplayServiceUrl: http://akto-puppeteer-replay:3000
       useHostName: true
       databaseAbstractorUrl: https://aquaman.akto.io
-      databaseAbstractorToken: ""
+      databaseAbstractorToken: 
+        # Optional -- Name of an existing secret containing the Database Abstractor Token
+        existingSecret: ""
+        # Optional -- Token to use if existingSecret is not provided
+        token: ""
     image:
       repository: public.ecr.aws/aktosecurity/akto-api-security-mini-runtime
       tag: latest


### PR DESCRIPTION
Adding support for a secrets object that can be overridden with an existing secret


Testing:
```
# You should get a secrets resource with a base64 encoded token
helm template . -n akto -s templates/secret.yaml --set mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorToken.existingSecret="" --set mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorToken.token="test"

# You should get no secrets resource
helm template . -n akto -s templates/secret.yaml --set mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorToken.existingSecret="mySecret"

# Look at the release-name-akto-mini-runtime-mini-runtime deployment, verify expected output
helm template . -n akto -s templates/deployment.yaml --set mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorToken.existingSecret="mySecret"

# Expected output
- name: DATABASE_ABSTRACTOR_SERVICE_TOKEN
   valueFrom:
     secretKeyRef:
       key: token
       name: mySecret
      
# Look at the release-name-akto-mini-runtime-mini-runtime deployment, verify expected output
helm template . -n akto -s templates/deployment.yaml --set mini_runtime.aktoApiSecurityRuntime.env.databaseAbstractorToken.token="1234"  

# Expected output
- name: DATABASE_ABSTRACTOR_SERVICE_TOKEN
   valueFrom:
     secretKeyRef:
       key: token
       name: release-name-akto-mini-runtime-mini-runtime
```