### PR TITLE
add node affinity, tolerations, and nodeSelector support

### DIFF
--- a/charts/data-ingestion-service/templates/deployment.yaml
+++ b/charts/data-ingestion-service/templates/deployment.yaml
@@ -14,6 +14,18 @@ spec:
       labels:
         {{- include "data-ingestion-service.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: {{ .Values.dataIngestionService.restartPolicy }}
       containers:
       - name: data-ingestion-service

--- a/charts/data-ingestion-service/values.yaml
+++ b/charts/data-ingestion-service/values.yaml
@@ -1,5 +1,28 @@
 kubernetesClusterDomain: cluster.local
 
+# Node scheduling configuration
+nodeSelector: {}
+  # Example usage:
+  # nodetype: coreservices
+
+tolerations: []
+  # Example usage:
+  # - key: nodetype
+  #   operator: Equal
+  #   value: coreservices
+  #   effect: NoSchedule
+
+affinity: {}
+  # Example usage:
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: nodetype
+  #         operator: In
+  #         values:
+  #         - coreservices
+
 dataIngestionService:
   image:
     repository: aktosecurity/data-ingestion-service


### PR DESCRIPTION
…stion-service

Added node scheduling configuration options to allow users to control pod placement:
- nodeSelector for simple node selection
- tolerations for scheduling on tainted nodes
- affinity for advanced node affinity rules

This follows the same pattern used in mini-runtime chart for consistency.